### PR TITLE
Transition to using `anyhow::Error` instead of `String`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ interprocess = {version="1.2.1", features=["tokio_support"]}
 futures = "0.3.25"
 tokio-test = "0.4.2"
 anyhow = "1.0.69"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 test-log = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.23.0", features=["net", "time", "io-util", "rt", "macros"
 interprocess = {version="1.2.1", features=["tokio_support"]}
 futures = "0.3.25"
 tokio-test = "0.4.2"
+anyhow = "1.0.69"
 
 [dev-dependencies]
 test-log = "0.2.11"

--- a/src/api/core_instruction_handler.rs
+++ b/src/api/core_instruction_handler.rs
@@ -8,6 +8,7 @@ use super::schema::{
 use log::{trace, error};
 use std::sync::Arc;
 
+use anyhow::Result;
 /// A trait to be implemented by the core for instructions sent from a plugin
 /// Also can be implemented by the plugin SDK, which can then be translated
 /// to instructions, and back again in the core.
@@ -20,7 +21,7 @@ pub trait CoreInstructionHandler {
 /// A function that finishes processing the CoreInstruction, and sends the
 /// data to the correct function on the given handler function.
 pub fn call_core_handler(unprocessed_instr: CoreInstruction,
-    interface: Arc<dyn CoreInstructionHandler>) -> Result<(), String>
+    interface: Arc<dyn CoreInstructionHandler>) -> Result<()>
 {
     match unprocessed_instr.instruction_type {
         CoreInstructionType::Init => {
@@ -32,7 +33,7 @@ pub fn call_core_handler(unprocessed_instr: CoreInstruction,
                 },
                 Err(e) => {
                     error!("Invalid data for instruction type Init.");
-                    return Err(e.to_string());
+                    return Err(e.into());
                 }
             }
         },
@@ -45,7 +46,7 @@ pub fn call_core_handler(unprocessed_instr: CoreInstruction,
                 },
                 Err(e) => {
                     error!("Invalid data for instruction type AuthAccountResponse.");
-                    return Err(e.to_string());
+                    return Err(e.into());
                 }
             }
 
@@ -59,7 +60,7 @@ pub fn call_core_handler(unprocessed_instr: CoreInstruction,
                 },
                 Err(e) => {
                     error!("Invalid data for instruction type Keepalive.");
-                    return Err(e.to_string());
+                    return Err(e.into());
                 }
             }
 

--- a/src/api/plugin_instruction_handler.rs
+++ b/src/api/plugin_instruction_handler.rs
@@ -4,6 +4,8 @@ use super::schema::{
     instructions::{PluginInstruction, PluginInstructionType}
 };
 
+use anyhow::Result;
+
 use log::{trace, error};
 use std::sync::Arc;
 
@@ -17,7 +19,7 @@ pub trait PluginInstructionHandler {
 /// A function that finishes processing the PluginInstruction, and sends the
 /// data to the correct function on the given handler function.
 pub fn call_core_handler(unprocessed_instr: PluginInstruction,
-    interface: Arc<dyn PluginInstructionHandler>) -> Result<(), String>
+    interface: Arc<dyn PluginInstructionHandler>) -> Result<()>
 {
     match unprocessed_instr.instruction_type {
         PluginInstructionType::AuthAccount => {
@@ -29,7 +31,7 @@ pub fn call_core_handler(unprocessed_instr: PluginInstruction,
                 },
                 Err(e) => {
                     error!("Invalid data for instruction type AuthAccountInstruction.");
-                    return Err(e.to_string());
+                    return Err(e.into());
                 }
             }
 
@@ -43,7 +45,7 @@ pub fn call_core_handler(unprocessed_instr: PluginInstruction,
                 },
                 Err(e) => {
                     error!("Invalid data for instruction type Keepalive.");
-                    return Err(e.to_string());
+                    return Err(e.into());
                 }
             }
 

--- a/src/client_sdk/socket.rs
+++ b/src/client_sdk/socket.rs
@@ -11,6 +11,8 @@ use crate::{
     utils::socket::*
 };
 
+use anyhow::Result;
+
 #[derive(Debug)]
 pub struct SocketCommunicator {
     reader: OwnedReadHalf,
@@ -18,11 +20,11 @@ pub struct SocketCommunicator {
 }
 
 impl SocketCommunicator {
-    pub async fn new(name: String) -> Result<SocketCommunicator, String> {
+    pub async fn new(name: String) -> Result<SocketCommunicator> {
         let stream = match LocalSocketStream::connect(get_socket_name(name)).await {
             Ok(s) => s,
             Err(e) => {
-                return Err(e.to_string());
+                return Err(e.into());
             }
         };
         let (reader, writer) = stream.into_split();
@@ -32,16 +34,16 @@ impl SocketCommunicator {
         })
     }
 
-    pub async fn send_core_instruction(&mut self, msg: &CoreInstruction) -> Result<(), String>{
+    pub async fn send_core_instruction(&mut self, msg: &CoreInstruction) -> Result<()>{
         let payload = convert_struct_to_str(msg)?;
         Ok(send_str_over_ipc(&payload, &mut self.writer).await?)
     }
 
-    pub async fn recv_plugin_instruction(&mut self) -> Result<PluginInstruction, String> {
+    pub async fn recv_plugin_instruction(&mut self) -> Result<PluginInstruction> {
         let data  = match receive_line(&mut self.reader).await {
             Ok(s) => s,
             Err(e) => {
-                return Err(e.to_string());
+                return Err(e.into());
             }
         };
         

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,8 @@ pub mod socket_handler;
 
 use socket_handler::SocketHandler;
 
+use anyhow::Result;
+
 pub struct Core {
     socket_hadler: SocketHandler
 }
@@ -14,13 +16,8 @@ impl Core {
      * A valid `Core` object on success
      * A string describing the error on failure (more details can be found in logs, adjust `RUST_LOG` level)
      */
-    pub fn new() -> Result<Core, String> {
-        let handler = match SocketHandler::new("polychat") {
-            Ok(s) => s,
-            Err(e) => {
-                return Err(e);
-            }
-        };
+    pub fn new() -> Result<Core> {
+        let handler = SocketHandler::new("polychat")?;
 
         Ok(Core {
             socket_hadler: handler

--- a/src/core/socket_handler.rs
+++ b/src/core/socket_handler.rs
@@ -37,7 +37,7 @@ impl SocketHandler {
      * - Windows/Linux - Creates a namespaced socket (@[`socket_name`](#socket_name).sock)
      * - BSD/Mac/\*NIX - Creates a filepath socket at /tmp/[`socket_name`](#socket_name).sock
      **/
-    pub fn new<S>(socket_name: S) -> Result<Self, String> where S: Into<String> + std::fmt::Display {
+    pub fn new<S>(socket_name: S) -> Result<Self> where S: Into<String> + std::fmt::Display {
         let name = get_socket_name(socket_name);
 
         debug!("Attempting to start server at {}", name);
@@ -45,7 +45,7 @@ impl SocketHandler {
             Ok(l) => l,
             Err(e) => {
                 error!("Could not start server: {}", e);
-                return Err(e.to_string());
+                return Err(e.into());
             }
         };
         debug!("Server started at {}", name);

--- a/src/process_management/error.rs
+++ b/src/process_management/error.rs
@@ -1,13 +1,13 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum ProcessManagerError<'a> {
+pub enum ProcessManagerError {
     #[error("Path '{0}' does not exist")]
-    NonExistent(&'a Path),
+    NonExistent(PathBuf),
     #[error("'{0}' is a relative path")]
-    RelativePath(&'a Path),
+    RelativePath(PathBuf),
     #[error("'{0}' is not a directory")]
-    NonDirectory(&'a Path)
+    NonDirectory(PathBuf)
 }

--- a/src/process_management/error.rs
+++ b/src/process_management/error.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ProcessManagerError<'a> {
+    #[error("Path '{0}' does not exist")]
+    NonExistent(&'a Path),
+    #[error("'{0}' is a relative path")]
+    RelativePath(&'a Path),
+    #[error("'{0}' is not a directory")]
+    NonDirectory(&'a Path)
+}

--- a/src/process_management/mod.rs
+++ b/src/process_management/mod.rs
@@ -1,2 +1,3 @@
 pub mod process;
 pub mod process_manager;
+mod error;

--- a/src/process_management/process.rs
+++ b/src/process_management/process.rs
@@ -4,17 +4,15 @@ use std::{
 };
 
 use log::{warn, debug};
-
+use anyhow::Result;
 #[derive(Debug)]
 pub struct Process {
     child: Child,
 }
 
 impl Process {
-    pub fn new<T: AsRef<OsStr> + std::fmt::Debug>(path: T) -> Result<Process, String> {
-        let child = Command::new(&path).stdout(Stdio::null()).spawn();
-
-        match child {
+    pub fn new<T: AsRef<OsStr> + std::fmt::Debug>(path: T) -> Result<Process> {
+        match Command::new(&path).stdout(Stdio::null()).spawn() {
             Ok(child) => {
                 debug!("Successfully started process {:?} with PID {}", path, child.id());
                 Ok(Process {
@@ -23,9 +21,7 @@ impl Process {
             },
             Err(e) => {
                 debug!("Could not load process from path {:?}: {}", &path, e);
-                Err(
-                    format!("Could not load process from path {:?}: {}", path, e)
-                )
+                Err(e.into())
             }
         }
     }

--- a/src/process_management/process_manager.rs
+++ b/src/process_management/process_manager.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsStr,
-    path::Path
+    path::PathBuf, str::FromStr
 };
 use log::{error, warn, debug};
 use walkdir::{DirEntry, WalkDir};
@@ -38,8 +38,8 @@ impl ProcessManager {
      * - Windows: Expects `.exe` to be the extension of the executables
      * - Everything Else: Expects no extension on the executables
      */
-    pub fn new(path: &'static str) -> Result<ProcessManager> {
-        ProcessManager::from_path(Path::new(path))
+    pub fn new(path: &str) -> Result<ProcessManager> {
+        ProcessManager::from_path(PathBuf::from_str(path)?)
     }
 
     /**
@@ -58,8 +58,8 @@ impl ProcessManager {
      * - Windows: Expects `.exe` to be the extension of the executables
      * - Everything Else: Expects no extension on the executables
      */
-    pub fn from_path(dir: &'static Path) -> Result<ProcessManager> {
-        check_directory(dir)?;
+    pub fn from_path(dir: PathBuf) -> Result<ProcessManager> {
+        check_directory(dir.clone())?;
 
         let dir_walk = WalkDir::new(dir).max_depth(2).min_depth(2).follow_links(false);
         let mut exec_vec: Vec<Process> = Vec::new();
@@ -106,7 +106,7 @@ impl ProcessManager {
  * 
  * A string slice describing why it does not meet all criteria on failure
  */
-fn check_directory(dir: &Path) -> Result<(), ProcessManagerError> {
+fn check_directory(dir: PathBuf) -> Result<(), ProcessManagerError> {
     if !dir.is_absolute() {
         let err = ProcessManagerError::RelativePath(dir);
         error!("{}", err);


### PR DESCRIPTION
This PR changes the usage of `Result<T, String>` to using `Result<T, anyhow::Error>` (aliased as `Result<T>`).

This gives more details upstream, and makes it easier to just use `?` when logging is not needed.

When logging is needed, `Err(e.into())` is all that is required.