### PR TITLE
Progress towards making it work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0.152", features=["derive"] }
 serde_json = { version = "1.0.91", features=["raw_value"] }
 log = "0.4.17"
 walkdir = "2.3.2"
-tokio = { version = "1.23.0", features=["net", "time", "io-util", "rt", "macros", "rt-multi-thread", "sync"]}
+tokio = { version = "1.25.0", features=["net", "time", "io-util", "rt", "macros", "rt-multi-thread", "sync"]}
 interprocess = {version="1.2.1", features=["tokio_support"]}
 futures = "0.3.25"
 tokio-test = "0.4.2"

--- a/src/api/core_instruction_handler.rs
+++ b/src/api/core_instruction_handler.rs
@@ -2,7 +2,7 @@ use super::schema::{
     auth::{AuthAccountResponse},
     protocol::InitDataInstruction,
     keepalive::KeepaliveInstruction,
-    instructions::{CoreInstruction, CoreInstructionType},
+    instructions::{CoreInstructionType, DeserializableCoreInstr},
 };
 
 use log::{trace, error};
@@ -20,7 +20,7 @@ pub trait CoreInstructionHandler {
 
 /// A function that finishes processing the CoreInstruction, and sends the
 /// data to the correct function on the given handler function.
-pub fn call_core_handler(unprocessed_instr: CoreInstruction,
+pub fn call_core_handler(unprocessed_instr: &DeserializableCoreInstr,
     interface: Arc<dyn CoreInstructionHandler>) -> Result<()>
 {
     match unprocessed_instr.instruction_type {

--- a/src/api/plugin_instruction_handler.rs
+++ b/src/api/plugin_instruction_handler.rs
@@ -1,7 +1,7 @@
 use super::schema::{
     auth::AuthAccountInstruction,
     keepalive::KeepaliveInstruction,
-    instructions::{PluginInstruction, PluginInstructionType}
+    instructions::{PluginInstructionType, DeserializablePluginInstr}
 };
 
 use anyhow::Result;
@@ -18,7 +18,7 @@ pub trait PluginInstructionHandler {
 
 /// A function that finishes processing the PluginInstruction, and sends the
 /// data to the correct function on the given handler function.
-pub fn call_core_handler(unprocessed_instr: PluginInstruction,
+pub fn call_core_handler(unprocessed_instr: &DeserializablePluginInstr,
     interface: Arc<dyn PluginInstructionHandler>) -> Result<()>
 {
     match unprocessed_instr.instruction_type {

--- a/src/client_sdk/mod.rs
+++ b/src/client_sdk/mod.rs
@@ -1,1 +1,0 @@
-pub mod socket;

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,27 @@
+# PolyChat Core
+
+PolyChat Core is the centralized component that sits between the user interface and the plugin system.
+
+The GUI initializes the core immediately on startup. The GUI then makes calls for things it needs, like getting account, plugin, or conversation info.
+
+## Responsibilities of PolyChat Core
+
+Plugins:
+- The core is responsible for interfacing with the plugin system. The GUI should not directly interface with the plugin system.
+- The core is responsible for sending and receiving plugin instructions, minus what the plugin system is responsible for.
+- TBD: Whether or not the plugin system or core should be responsible for keepalive requests.
+- The core is not responsible for isolating itself from a plugin crash. The plugin system is responsible for that. But the core is reasponsible for alerting the GUI so that it may update the GUI to show a crashed plugin and the related error message(s).
+- The core is responsible for loading all relevant information from the Init instruction from the plugin.
+
+Accounts:
+- The core is responsible for making the login methods for all supported protocols available to the GUI.
+- The core is responsible for keeping track of the authenticated and session-expired accounts.
+
+Conversations:
+- The core is responsible for keeping track of all conversations for all accounts, and making them available to the GUI.
+- The core is responsible for keeping track of all information related to conversations. This includes requesting more messages, and sending messages when the GUI sends the instruction to the core.
+
+Networking:
+- The core will not be responsible for handling network connections. Plugins will be more strongly isolated from the core, and will handle it themselves.
+- The core will be responsible for aiding in the creation of request IDs that will be associated with any action that is being requested of a plugin.
+- The core will be responsible for validating that a plugin does as it is requested. If a request, with an associated request ID, stalls, times out, or does not do what it was supposed to, the core should flag that as a plugin error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod api;
 pub mod process_management;
 pub mod core;
-pub mod client_sdk;
+pub mod polychat_plugin_sdk_rust;
 pub mod utils;

--- a/src/polychat_plugin_sdk_rust/README.md
+++ b/src/polychat_plugin_sdk_rust/README.md
@@ -1,0 +1,7 @@
+# PolyChat Plugin SDK Rust
+
+The PolyChat Plugin SDK Rust is an official plugin SDK written in Rust allow your plugin to interface with PolyChat.
+
+Components:
+- SocketCommunicator: Handles IPC communication.
+- entrypoint::run_plugin: A function that handles the expected behavior when the plugin is launched. This includes getting the socket/pipe ID, starting the SocketCommunicator, and sending the init instruction.

--- a/src/polychat_plugin_sdk_rust/entrypoint.rs
+++ b/src/polychat_plugin_sdk_rust/entrypoint.rs
@@ -1,0 +1,38 @@
+use std::env;
+
+use crate::api::schema::{instructions::{CoreInstructionType, SerializableCoreInstr}, protocol::{InitDataInstruction, Version, ProtocolData}};
+use log::error;
+use super::socket::SocketCommunicator;
+
+// A blocking function that determines the socket name from command line args,
+// then opens the socket.
+pub async fn run_plugin() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 1 {
+        panic!("Incorrect number of args while running plugin. Got {}, expected 1.", args.len());
+    }
+    let socket_id = args[0].clone();
+
+    let ipc_connection = SocketCommunicator::new(socket_id).await;
+    match ipc_connection {
+        Ok(mut connection) => {
+            // TODO: Make it so the plugin passes this in instead of using example data.
+            let instr_payload = InitDataInstruction {
+                api_version: Version {major: 0, minor: 1, patch: 0},
+                plugin_version: Version {major: 0, minor: 1, patch: 0},
+                protocol_data: ProtocolData { protocol_service_name: "example_protocol".to_string(), auth_methods: vec![] },
+            };
+            let init_instr = SerializableCoreInstr {
+                instruction_type: CoreInstructionType::Init,
+                payload: instr_payload,
+            };
+            let send_result = connection.send_core_instruction(&init_instr).await;
+            if send_result.is_err() {
+                error!("Error while trying to send core instruction: {:?}", send_result.err())
+            }
+        },
+        Err(e) => {
+            panic!("Error while opening IPC connection. Error: {}", e);
+        }
+    }
+}

--- a/src/polychat_plugin_sdk_rust/mod.rs
+++ b/src/polychat_plugin_sdk_rust/mod.rs
@@ -1,0 +1,2 @@
+pub mod socket;
+pub mod entrypoint;

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -1,4 +1,5 @@
-use std::{any::type_name, fmt::Display};
+use std::fmt::Debug;
+use std::any::type_name;
 
 use interprocess::local_socket::tokio::{OwnedReadHalf, OwnedWriteHalf};
 use interprocess::local_socket::NameTypeSupport;
@@ -39,11 +40,11 @@ pub fn convert_str_to_struct<'a, T>(data: &'a String) -> Result<T> where T: Dese
     }
 }
 
-pub fn convert_struct_to_str<T>(msg: &T) -> Result<String> where T: Serialize + Display {
+pub fn convert_struct_to_str<'a, T: 'a>(msg: &T) -> Result<String> where T: Serialize + Debug {
     match serde_json::to_string(msg) {
         Ok(s) => Ok(s),
         Err(e) => {
-            debug!("Error serializing {}: {}", msg, e.to_string());
+            debug!("Error serializing {:?}: {}", msg, e.to_string());
             return Err(e.into());
         }
     }


### PR DESCRIPTION
Summary:
- Renamed Rust Plugin SDK, and added an entrypoint function that should establish the IPC connection.
- Created separate instruction structs for serialization and deserialization.


A lot of the changes in this PR are subject to change as the project is in a fast-paced time where some changes will work out better than others.
This PR should help a lot. First, with the separated structs, serializing the packets is possible now. Second, the plugin SDK should be a good starting point for plugins. Further testing for that will come later.