### PR TITLE
Plugin integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "test-plugin"
+test = false
+bench = false
+
 [dependencies]
 serde = { version = "1.0.152", features=["derive"] }
 serde_json = { version = "1.0.91", features=["raw_value"] }
@@ -21,3 +26,4 @@ thiserror = "1.0.38"
 test-log = "0.2.11"
 env_logger = "0.10.0"
 rstest = "0.16.0"
+assert_cmd = "2.0"

--- a/src/bin/test-plugin/main.rs
+++ b/src/bin/test-plugin/main.rs
@@ -1,0 +1,11 @@
+use tokio;
+extern crate polychat_ipc;
+use polychat_ipc::polychat_plugin_sdk_rust::entrypoint;
+//use log::info;
+
+#[tokio::main]
+async fn main() {
+    println!("Test Example plugin starting.");
+    entrypoint::run_plugin().await;
+    println!("Test Example plugin finished running.");
+}

--- a/src/polychat_plugin_sdk_rust/entrypoint.rs
+++ b/src/polychat_plugin_sdk_rust/entrypoint.rs
@@ -8,10 +8,10 @@ use super::socket::SocketCommunicator;
 // then opens the socket.
 pub async fn run_plugin() {
     let args: Vec<String> = env::args().collect();
-    if args.len() != 1 {
-        panic!("Incorrect number of args while running plugin. Got {}, expected 1.", args.len());
+    if args.len() != 2 {
+        panic!("Incorrect number of args while running plugin. Got {}, expected 2.", args.len());
     }
-    let socket_id = args[0].clone();
+    let socket_id = args[1].clone();
 
     let ipc_connection = SocketCommunicator::new(socket_id).await;
     match ipc_connection {

--- a/src/polychat_plugin_sdk_rust/socket.rs
+++ b/src/polychat_plugin_sdk_rust/socket.rs
@@ -42,7 +42,7 @@ impl SocketCommunicator {
         Ok(send_str_over_ipc(&payload, &mut self.writer).await?)
     }
 
-    pub async fn recv_plugin_instruction(&mut self) -> Result<()> {
+    pub async fn recv_plugin_instruction(&mut self) -> Result<DeserializablePluginInstr> {
         let data  = match receive_line(&mut self.reader).await {
             Ok(s) => s,
             Err(e) => {
@@ -51,10 +51,8 @@ impl SocketCommunicator {
         };
         
         return match convert_str_to_struct::<DeserializablePluginInstr>(&data) {
-            Ok(_plugin_instr) => {
-                // TODO: Call trait that automates getting the data from the packet and
-                // calling the appropriate handler
-                Ok(())
+            Ok(plugin_instr) => {
+                Ok(plugin_instr)
             },
             Err(e) => {
                 Err(e)

--- a/tests/socket_int_test.rs
+++ b/tests/socket_int_test.rs
@@ -58,10 +58,9 @@ mod test {
 
         assert_ok!(server.send_plugin_instruction(&instruct).await);
 
-        assert_ok!(client.recv_plugin_instruction().await);
-        //assert_eq!(instruct, recv);
-        // TODO: Pass in the interface, and use that to determine whether it successfully
-        // gets the correct data.
+        let recv = assert_ok!(client.recv_plugin_instruction().await);
+        assert_eq!(instruct.instruction_type, recv.instruction_type);
+        assert_eq!(instruct.payload.to_string(), recv.payload.to_string());
     }
 
     fn create_handler(name: String) -> SocketHandler {

--- a/tests/test_plugin_tests.rs
+++ b/tests/test_plugin_tests.rs
@@ -1,0 +1,49 @@
+// Tests that utilize the test plugin binary.
+// These tests are useful because they can test all features end-to-end.
+
+#[cfg(test)]
+mod test {
+    use polychat_ipc::{core::socket_handler::SocketHandler};
+    use rstest::*;
+    use tokio_test::assert_ok;
+    use std::process::Command;
+    use assert_cmd::prelude::*; // Add methods on command
+    use log::debug;
+
+    /// This function:
+    /// - Starts the necessary components of the core
+    /// - Starts the plugin
+    /// - Verifies that the plugin sent the Init core instruction.
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn integration_test_plugin_init() {
+        // Start the component from core that starts the IPC connections.
+        debug!("Starting socket");
+        let socket_name = format!("test_plugin_test_init");
+        let handler = create_handler(socket_name.clone());
+        
+        // Start the plugin
+        debug!("Starting plugin");
+        let mut cmd = Command::cargo_bin("test-plugin").unwrap();
+        cmd.arg(socket_name.clone());
+        let plugin_output = cmd.unwrap();
+        debug!("Output of plugin: {:?}", plugin_output);
+        debug!("Started plugin");
+
+        // Process the connection
+        let conn = assert_ok!(handler.get_connection().await);
+        debug!("Received connection");
+
+        // Await the init instruction
+        let recv_res = handler.get_core_instruction_data(conn);
+        let recv_res = assert_ok!(recv_res.await);
+        debug!("Received data: {}", recv_res);
+        assert_ok!(handler.handle_recv_core_message(recv_res).await);
+        debug!("Done");
+    }
+
+    fn create_handler(name: String) -> SocketHandler {
+        assert_ok!(SocketHandler::new(name))
+    }
+
+}


### PR DESCRIPTION
This PR adds integration tests that utilize the actual binary.

Due to the state of the core, it just starts the process itself and loads it. Then verifies it got the Init instruction.

This PR also fixes a change to the other integration test so that it verifies more.